### PR TITLE
chore(ci): separate the release and review steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+      - master
 
 jobs:
-  make:
+  release:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,5 +18,7 @@ jobs:
         with:
           go-version: ^1.17
 
-      - name: Make
-        run: make
+      - name: Run semantic-release
+        run: make semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.EINRIDEBOT_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
makes it so that the release is only run on a push to master and not on every PR.