### PR TITLE
fix(ci): change token to `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Release
 
 on:
   push:
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -21,4 +23,4 @@ jobs:
       - name: Run semantic-release
         run: make semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.EINRIDEBOT_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allow write access to contents on the release job. Also changed in repo settings is that the token is granted read only permissions by default.

https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/

https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/