### PR TITLE
feat(commands): `shift+r` to recreate PR

### DIFF
--- a/tui_cmds.go
+++ b/tui_cmds.go
@@ -54,6 +54,19 @@ func rebasePullRequest(pr pullRequest) tea.Cmd {
 	}
 }
 
+type pullRequestRecreated struct {
+	pr pullRequest
+}
+
+func recreatePullRequest(pr pullRequest) tea.Cmd {
+	return func() tea.Msg {
+		if _, err := gh.Run("pr", "comment", "--body", "@dependabot recreate", pr.url); err != nil {
+			return errorMessage{err: err}
+		}
+		return pullRequestRecreated{pr: pr}
+	}
+}
+
 type pullRequestOpenedInBrowser struct {
 	pr pullRequest
 }

--- a/tui_list.go
+++ b/tui_list.go
@@ -19,6 +19,7 @@ type keyMap struct {
 	mergeSquash     key.Binding
 	mergeDependabot key.Binding
 	rebase          key.Binding
+	recreate        key.Binding
 	view            key.Binding
 	browse          key.Binding // open PR in default browser.
 	copyCheckout    key.Binding
@@ -46,6 +47,10 @@ func newKeyMap() *keyMap {
 			key.WithKeys("r"),
 			key.WithHelp("r", "rebase"),
 		),
+		recreate: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("shift+r", "recreate"),
+		),
 		browse: key.NewBinding(
 			key.WithKeys("b"),
 			key.WithHelp("b", "open in browser"),
@@ -68,6 +73,7 @@ func (d keyMap) Bindings() []key.Binding {
 		d.mergeSquash,
 		d.mergeDependabot,
 		d.rebase,
+		d.recreate,
 		d.view,
 		d.browse,
 		d.copyCheckout,
@@ -108,6 +114,9 @@ func (m ListView) Update(msg tea.Msg) (ListView, tea.Cmd) {
 	case pullRequestRebased:
 		m.listModel.StopSpinner()
 		cmds = append(cmds, m.listModel.NewStatusMessage("Rebased "+msg.pr.url))
+	case pullRequestRecreated:
+		m.listModel.StopSpinner()
+		cmds = append(cmds, m.listModel.NewStatusMessage("Recreated "+msg.pr.url))
 	case pullRequestOpenedInBrowser:
 		m.listModel.StopSpinner()
 		cmds = append(cmds, m.listModel.NewStatusMessage("Opened "+msg.pr.url))
@@ -158,6 +167,14 @@ func (m ListView) Update(msg tea.Msg) (ListView, tea.Cmd) {
 					cmds,
 					m.listModel.StartSpinner(),
 					rebasePullRequest(selectedItem),
+				)
+			}
+		case key.Matches(msg, m.keyMap.recreate):
+			if selectedItem, ok := m.listModel.SelectedItem().(pullRequest); ok {
+				cmds = append(
+					cmds,
+					m.listModel.StartSpinner(),
+					recreatePullRequest(selectedItem),
 				)
 			}
 		case key.Matches(msg, m.keyMap.browse):


### PR DESCRIPTION
This command is useful when you know there is a later release and you want dependabot to switch to that one instead. Rebase can usually be used for this behaviour but only whenever there is actually newer commits on master.