### PR TITLE
Change the "open in browser" keyboard from "b" to "o"

### DIFF
--- a/tui_list.go
+++ b/tui_list.go
@@ -52,8 +52,8 @@ func newKeyMap() *keyMap {
 			key.WithHelp("shift+r", "recreate"),
 		),
 		browse: key.NewBinding(
-			key.WithKeys("b"),
-			key.WithHelp("b", "open in browser"),
+			key.WithKeys("o"),
+			key.WithHelp("o", "open in browser"),
 		),
 		view: key.NewBinding(
 			key.WithKeys("v"),


### PR DESCRIPTION
The "b" key is already defined as a keyboard shortcut in the charmbracelet/bubbles library, which means whenever the "b" key is pressed, it will both open the current item in a browser and navigate the list to the previous page.

The "o" key is however not used for anything so doesn't collide with any other actions.

Fixes https://github.com/einride/gh-dependabot/issues/89.