### PR TITLE
fix: support specifying both org and team in filter

### DIFF
--- a/pullrequest.go
+++ b/pullrequest.go
@@ -85,14 +85,15 @@ type pullRequestQuery struct {
 
 func (q pullRequestQuery) Filter() string {
 	filterStr := ""
-	switch {
-	case q.org != "":
-		filterStr += " org:" + q.org
-		fallthrough
-	case q.team != "":
-		filterStr += " team-review-requested:" + q.team
-	default:
+	if q.org == "" && q.team == "" {
 		filterStr += " review-requested:" + q.username
+	} else {
+		if q.org != "" {
+			filterStr += " org:" + q.org
+		}
+		if q.team != "" {
+			filterStr += " team-review-requested:" + q.team
+		}
 	}
 
 	return filterStr

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -84,18 +84,22 @@ type pullRequestQuery struct {
 }
 
 func (q pullRequestQuery) Filter() string {
+	filterStr := ""
 	switch {
 	case q.org != "":
-		return "org:" + q.org
+		filterStr += " org:" + q.org
+		fallthrough
 	case q.team != "":
-		return "team-review-requested:" + q.team
+		filterStr += " team-review-requested:" + q.team
 	default:
-		return "review-requested:" + q.username
+		filterStr += " review-requested:" + q.username
 	}
+
+	return filterStr
 }
 
 func (q pullRequestQuery) SearchQuery() string {
-	return "type:pr state:open archived:false author:app/dependabot " + q.Filter()
+	return "type:pr state:open archived:false author:app/dependabot" + q.Filter()
 }
 
 func loadPullRequestPage(client *githubv4.Client, prQuery pullRequestQuery) (*pullRequestPage, error) {


### PR DESCRIPTION
Current behavior is that one can specify org *or* team. If both are specified, only the org is added to the filter string.

This PR changes this behavior so that when both org and team are specified as arguments, both are added to the filter string.