### PR TITLE
feat: add security alert filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 		Use:     "gh dependabot",
 		Short:   "Manage Dependabot PRs.",
 		Example: "gh dependabot --org einride",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			log.Println("Resolving current user...")
 			username, err := gh.Run("api", "graphql", "-f", "query={viewer{login}}", "--jq", ".data.viewer.login")
 			if err != nil {
@@ -57,7 +57,7 @@ func main() {
 
 			if securityFilter {
 				log.Printf("Matching pull requests to security alerts...")
-				pullRequests, err = filterSecurityPullRequests(client, &pullRequests)
+				pullRequests, err = filterSecurityPullRequests(cmd.Context(), client, &pullRequests)
 				if err != nil {
 					return err
 				}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	})
 	var org string
 	var team string
+	var securityFilter bool
 	cmd := cobra.Command{
 		Use:     "gh dependabot",
 		Short:   "Manage Dependabot PRs.",
@@ -53,6 +54,15 @@ func main() {
 				pullRequests = append(pullRequests, nextPage.PullRequests...)
 				page = nextPage
 			}
+
+			if securityFilter {
+				log.Printf("Matching pull requests to security alerts...")
+				pullRequests, err = filterSecurityPullRequests(client, &pullRequests)
+				if err != nil {
+					return err
+				}
+			}
+
 			sort.Slice(pullRequests, func(i, j int) bool {
 				return pullRequests[i].updatedAt.Before(pullRequests[j].updatedAt)
 			})
@@ -62,6 +72,8 @@ func main() {
 	}
 	cmd.Flags().StringVarP(&org, "org", "o", "", "organization to query (e.g. einride)")
 	cmd.Flags().StringVarP(&team, "team", "t", "", "team to query (e.g. einride/team-transport-execution)")
+	cmd.Flags().
+		BoolVarP(&securityFilter, "only-security", "s", false, "show only pull requests that relate to security alerts")
 	if err := cmd.Execute(); err != nil {
 		log.Fatalln(err)
 	}

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ func main() {
 				pullRequests = append(pullRequests, nextPage.PullRequests...)
 				page = nextPage
 			}
-
 			if securityFilter {
 				log.Printf("Matching pull requests to security alerts...")
 				pullRequests, err = filterSecurityPullRequests(cmd.Context(), client, &pullRequests)
@@ -62,7 +61,6 @@ func main() {
 					return err
 				}
 			}
-
 			sort.Slice(pullRequests, func(i, j int) bool {
 				return pullRequests[i].updatedAt.Before(pullRequests[j].updatedAt)
 			})

--- a/securityfilter.go
+++ b/securityfilter.go
@@ -9,6 +9,7 @@ import (
 )
 
 func filterSecurityPullRequests(
+	ctx context.Context,
 	client *githubv4.Client,
 	pullRequests *[]pullRequest,
 ) ([]pullRequest, error) {
@@ -35,7 +36,7 @@ func filterSecurityPullRequests(
 		}
 		var vulnQ vulnQuery
 
-		if err := client.Query(context.Background(), &vulnQ, vulnVars); err != nil {
+		if err := client.Query(ctx, &vulnQ, vulnVars); err != nil {
 			return nil, fmt.Errorf("load vulnerability reports: %w", err)
 		}
 		for _, vulnAlert := range vulnQ.Repository.VulnerabilityAlerts.Nodes {

--- a/securityfilter.go
+++ b/securityfilter.go
@@ -35,7 +35,6 @@ func filterSecurityPullRequests(
 			"name":  githubv4.String(pr.repository),
 		}
 		var vulnQ vulnQuery
-
 		if err := client.Query(ctx, &vulnQ, vulnVars); err != nil {
 			return nil, fmt.Errorf("load vulnerability reports: %w", err)
 		}
@@ -58,6 +57,5 @@ func filterSecurityPullRequests(
 			}
 		}
 	}
-
 	return filteredPullRequests, nil
 }

--- a/securityfilter.go
+++ b/securityfilter.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shurcooL/githubv4"
+)
+
+func filterSecurityPullRequests(
+	client *githubv4.Client,
+	pullRequests *[]pullRequest,
+) ([]pullRequest, error) {
+	filteredPullRequests := []pullRequest{}
+	for _, pr := range *pullRequests {
+		type vulnQuery struct {
+			Repository struct {
+				VulnerabilityAlerts struct {
+					Nodes []struct {
+						VulnerableRequirements string
+						State                  string
+						SecurityVulnerability  struct {
+							Package struct {
+								Name string
+							}
+						}
+					}
+				} `graphql:"vulnerabilityAlerts(first:100,states:OPEN)"`
+			} `graphql:"repository(owner: $owner, name: $name)"`
+		}
+		vulnVars := map[string]interface{}{
+			"owner": githubv4.String(pr.owner),
+			"name":  githubv4.String(pr.repository),
+		}
+		var vulnQ vulnQuery
+
+		if err := client.Query(context.Background(), &vulnQ, vulnVars); err != nil {
+			return nil, fmt.Errorf("load vulnerability reports: %w", err)
+		}
+		for _, vulnAlert := range vulnQ.Repository.VulnerabilityAlerts.Nodes {
+			if strings.HasPrefix(
+				pr.bodyText,
+				fmt.Sprintf(
+					"Bumps %s from %s to ",
+					vulnAlert.SecurityVulnerability.Package.Name,
+					strings.Replace(
+						vulnAlert.VulnerableRequirements,
+						"= ",
+						"",
+						1,
+					),
+				),
+			) {
+				filteredPullRequests = append(filteredPullRequests, pr)
+				break
+			}
+		}
+	}
+
+	return filteredPullRequests, nil
+}


### PR DESCRIPTION
Adds a flag to filter on only pull requests that relate to a security advisory. This can be helpful for teams that get a huge amount of Dependabot PR's but want to focus on merging the ones that are security related.

The API unfortunately doesn't provide a native way to retrieve which PR's relate to vulnerability alerts or the other way around, so inspiration has been taken from creative solutions like https://github.com/dependabot/fetch-metadata/blob/main/src/dependabot/verified_commits.ts#L59-L91 where package name and version from a repository's vulnerability alerts is matched against package name and version parsed from Dependabot PR's message body.