### PR TITLE
chore(deps): update dependabot run settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,41 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pr proposes to update the dependabot run settings for the repository, making the interval monthly, and merging patch and minor updates. 