### PR TITLE
fix: move off deprecated `@dependabot merge`

### DIFF
--- a/tui_cmds.go
+++ b/tui_cmds.go
@@ -25,7 +25,7 @@ const (
 	MethodRebase     mergeMethod = "--rebase"
 	MethodMerge      mergeMethod = "--merge"
 	MethodSquash     mergeMethod = "--squash"
-	MethodDependabot mergeMethod = "@dependabot merge"
+	MethodDependabot mergeMethod = "dependabot auto-merge"
 )
 
 type commander struct {
@@ -58,7 +58,19 @@ func (c commander) mergePullRequest(pr pullRequest, method mergeMethod) tea.Cmd 
 		case MethodDependabot:
 			//nolint:errcheck // hard coded limiter burst, can't fail
 			c.limiter.Wait(context.Background())
-			if _, err := gh.Run("pr", "review", "--approve", "--body", string(method), pr.url); err != nil {
+			// Check if rebase is needed before requesting it
+			if needsRebase(pr.url) {
+				if _, err := gh.Run("pr", "comment", "--body", "@dependabot rebase", pr.url); err != nil {
+					return errorMessage{err: err}
+				}
+			}
+			// Approve the PR
+			if _, err := gh.Run("pr", "review", "--approve", pr.url); err != nil {
+				return errorMessage{err: err}
+			}
+			// Try auto-merge first, then direct merge
+			// Try methods in order: rebase → squash → merge
+			if err := mergeWithFallback(pr.url); err != nil {
 				return errorMessage{err: err}
 			}
 		default:
@@ -66,6 +78,35 @@ func (c commander) mergePullRequest(pr pullRequest, method mergeMethod) tea.Cmd 
 		}
 		return pullRequestMerged{pr: pr}
 	}
+}
+
+// needsRebase checks if a PR branch is behind the base branch.
+// See https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+func needsRebase(url string) bool {
+	status, err := gh.Run("pr", "view", url, "--json", "mergeStateStatus", "--jq", ".mergeStateStatus")
+	if err != nil {
+		return false // If we can't check, skip the rebase request
+	}
+	return status == "BEHIND"
+}
+
+// mergeWithFallback tries to merge a PR using different methods in order of preference.
+// First tries auto-merge (rebase → squash → merge), then direct merge with the same order.
+func mergeWithFallback(url string) error {
+	methods := []string{"--rebase", "--squash", "--merge"}
+	// Try auto-merge first with each method
+	for _, method := range methods {
+		if _, err := gh.Run("pr", "merge", "--auto", method, url); err == nil {
+			return nil
+		}
+	}
+	// Fall back to direct merge with each method
+	for _, method := range methods {
+		if _, err := gh.Run("pr", "merge", method, url); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to merge PR: all merge methods failed")
 }
 
 type pullRequestRebased struct {

--- a/tui_cmds.go
+++ b/tui_cmds.go
@@ -28,6 +28,47 @@ const (
 	MethodDependabot mergeMethod = "dependabot auto-merge"
 )
 
+// mergeState represents the merge state status of a PR.
+// See https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+type mergeState int
+
+const (
+	mergeStateUnknown  mergeState = iota // The state has not been identified
+	mergeStateBehind                     // The head ref is out of date
+	mergeStateBlocked                    // The merge is blocked
+	mergeStateClean                      // Mergeable and passing commit status
+	mergeStateDirty                      // The merge commit cannot be cleanly created (conflicts)
+	mergeStateDraft                      // The merge is blocked due to the pull request being a draft
+	mergeStateHasHooks                   // Mergeable with passing commit status and pre-receive hooks
+	mergeStateUnstable                   // Mergeable with non-passing commit status
+)
+
+// getMergeState returns the merge state status of a PR.
+func getMergeState(url string) mergeState {
+	status, err := gh.Run("pr", "view", url, "--json", "mergeStateStatus", "--jq", ".mergeStateStatus")
+	if err != nil {
+		return mergeStateUnknown
+	}
+	switch status {
+	case "BEHIND":
+		return mergeStateBehind
+	case "BLOCKED":
+		return mergeStateBlocked
+	case "CLEAN":
+		return mergeStateClean
+	case "DIRTY":
+		return mergeStateDirty
+	case "DRAFT":
+		return mergeStateDraft
+	case "HAS_HOOKS":
+		return mergeStateHasHooks
+	case "UNSTABLE":
+		return mergeStateUnstable
+	default:
+		return mergeStateUnknown
+	}
+}
+
 type commander struct {
 	limiter *rate.Limiter
 }
@@ -58,21 +99,38 @@ func (c commander) mergePullRequest(pr pullRequest, method mergeMethod) tea.Cmd 
 		case MethodDependabot:
 			//nolint:errcheck // hard coded limiter burst, can't fail
 			c.limiter.Wait(context.Background())
-			// Check if rebase is needed before requesting it
-			if needsRebase(pr.url) {
-				if _, err := gh.Run("pr", "comment", "--body", "@dependabot rebase", pr.url); err != nil {
-					return errorMessage{err: err}
-				}
-			}
-			// Approve the PR
+			// Approve the PR first
 			if _, err := gh.Run("pr", "review", "--approve", pr.url); err != nil {
 				return errorMessage{err: err}
 			}
-			// Try auto-merge first, then direct merge
-			// Try methods in order: rebase → squash → merge
-			if err := mergeWithFallback(pr.url); err != nil {
-				return errorMessage{err: err}
+			// Check merge state
+			state := getMergeState(pr.url)
+			// Request rebase if branch is behind
+			var requestedRebase bool
+			if state == mergeStateBehind {
+				_, _ = gh.Run("pr", "comment", "--body", "@dependabot rebase", pr.url)
+				requestedRebase = true
 			}
+			// Scenario 1: Try auto-merge (preferred - waits for checks)
+			if tryAutoMerge(pr.url) {
+				return pullRequestMerged{pr: pr}
+			}
+			// Scenario 2: Auto-merge not available, try direct merge (only if mergeable)
+			if state == mergeStateClean || state == mergeStateHasHooks {
+				if err := directMerge(pr.url); err == nil {
+					return pullRequestMerged{pr: pr}
+				}
+			}
+			// Scenario 3: Behind and no auto-merge - rebase and post helpful comment
+			if !requestedRebase {
+				_, _ = gh.Run("pr", "comment", "--body", "@dependabot rebase", pr.url)
+			}
+			_, _ = gh.Run("pr", "comment", "--body",
+				"⚠️ This PR needs to be rebased before it can be merged. "+
+					"Auto-merge is not enabled for this repository.\n\n"+
+					"Consider enabling auto-merge in repository settings to simplify the merge process.",
+				pr.url)
+			return errorMessage{err: fmt.Errorf("PR rebasing - auto-merge unavailable, merge manually after rebase")}
 		default:
 			return errorMessage{err: fmt.Errorf("unknown merge method: %q", method)}
 		}
@@ -80,27 +138,24 @@ func (c commander) mergePullRequest(pr pullRequest, method mergeMethod) tea.Cmd 
 	}
 }
 
-// needsRebase checks if a PR branch is behind the base branch.
-// See https://docs.github.com/en/graphql/reference/enums#mergestatestatus
-func needsRebase(url string) bool {
-	status, err := gh.Run("pr", "view", url, "--json", "mergeStateStatus", "--jq", ".mergeStateStatus")
-	if err != nil {
-		return false // If we can't check, skip the rebase request
-	}
-	return status == "BEHIND"
-}
-
-// mergeWithFallback tries to merge a PR using different methods in order of preference.
-// First tries auto-merge (rebase → squash → merge), then direct merge with the same order.
-func mergeWithFallback(url string) error {
+// tryAutoMerge attempts to enable auto-merge on a PR.
+// If the branch is behind, it requests a rebase first.
+// Returns true if auto-merge was successfully enabled.
+// Tries methods in order: rebase → squash → merge.
+func tryAutoMerge(url string) bool {
 	methods := []string{"--rebase", "--squash", "--merge"}
-	// Try auto-merge first with each method
 	for _, method := range methods {
 		if _, err := gh.Run("pr", "merge", "--auto", method, url); err == nil {
-			return nil
+			return true
 		}
 	}
-	// Fall back to direct merge with each method
+	return false
+}
+
+// directMerge attempts to merge a PR directly without auto-merge.
+// Tries methods in order: rebase → squash → merge.
+func directMerge(url string) error {
+	methods := []string{"--rebase", "--squash", "--merge"}
 	for _, method := range methods {
 		if _, err := gh.Run("pr", "merge", method, url); err == nil {
 			return nil

--- a/tui_list.go
+++ b/tui_list.go
@@ -42,7 +42,7 @@ func newKeyMap() *keyMap {
 		),
 		mergeDependabot: key.NewBinding(
 			key.WithKeys("alt+m"),
-			key.WithHelp("alt+m", "merge (Dependabot)"),
+			key.WithHelp("alt+m", "rebase + auto-merge"),
 		),
 		rebase: key.NewBinding(
 			key.WithKeys("r"),


### PR DESCRIPTION
### Why?

GitHub has [decided to deprecate/remove `@dependabot merge`](https://github.blog/changelog/2025-10-07-upcoming-changes-to-github-dependabot-pull-request-comment-commands/
) and therefore this command will no longer work as of January 27th.

### What?

Replace the old `@dependabot merge` with new logic which attempts to:

- approve the PR
- rebase the PR
- merge the PR

```
  ┌──────────────────────────────┬───────────────────────┬─────────────────────────────┐                                
  │           Scenario           │       Detection       │           Action            │                                
  ├──────────────────────────────┼───────────────────────┼─────────────────────────────┤                                
  │ 1. Auto-merge available      │ tryAutoMerge succeeds │ Rebase + auto-merge enabled │                                
  ├──────────────────────────────┼───────────────────────┼─────────────────────────────┤                                
  │ 2. No auto-merge, up-to-date │ directMerge succeeds  │ Merged directly             │                                
  ├──────────────────────────────┼───────────────────────┼─────────────────────────────┤                                
  │ 3. No auto-merge, behind     │ directMerge fails     │ Rebase + helpful comment    │                                
  └──────────────────────────────┴───────────────────────┴─────────────────────────────┘                                
```

Attempts with fallback:

1. `gh pr merge --auto --rebase`
2. `gh pr merge --auto --squash`
3. `gh pr merge --auto --merge`
4. `gh pr merge --rebase`
5. `gh pr merge --squash`
6. `gh pr merge --merge`


### Notes

Try it out, from this branch:

```sh
go run . --org <your-org>
```